### PR TITLE
Quick API-fix 

### DIFF
--- a/utils/getAuth0Users.tsx
+++ b/utils/getAuth0Users.tsx
@@ -89,16 +89,27 @@ export class getUsers {
     }
 
     private async _getAllUsers() {
-
         const token = await this.token
-        const options = {
-            method: 'GET',
-            url: "https://lundsnation.eu.auth0.com/api/v2/users",
-            headers: { authorization: 'Bearer ' + token, 'content-type': 'application/json' }
+        let moreUsers = true
+        let page = 0
+        let finalData : Array<Object>= []
+        while(moreUsers){
+            const options = {
+                method: 'GET',
+                url: `https://lundsnation.eu.auth0.com/api/v2/users?page=${page}`,
+                headers: { authorization: 'Bearer ' + token, 'content-type': 'application/json' }
+            }
+            const response = await fetch(options.url, options)
+            const data = await response.json()   
+            finalData.push(...data)
+            if(data.length != 50){
+                moreUsers=false
+            }
+            else{
+                page += 1
+            }
         }
-        const response = await fetch(options.url, options)
-        const data = await response.json()
-        return data    
+        return finalData    
     }
 
     private async _getSpecificUser(key: string, value: string) {

--- a/utils/users/userList.py
+++ b/utils/users/userList.py
@@ -5,6 +5,7 @@ import getopt, sys
 from dotenv import load_dotenv
 import requests
 import re
+import time
 
 BUILDINGS = ["NH","GH","ARKIVET"]
 ARKIVET_BUILDINGS = ["A","B","C","D"]
@@ -56,7 +57,7 @@ def assertBuilding(buildingName):
 def run():
     fileDir = "utils/users/userLists" 
     folderName = os.path.join(os.getcwd(),fileDir)
-    nFiles = ["test.csv"]
+    nFiles = ["tenants13223.csv"]
     if(not TESTING_MODE):
         print(os.getcwd())
         nFiles = os.listdir(folderName)
@@ -95,6 +96,7 @@ def run():
             #testReq = requests.Request("POST",endpoint,headers=postHeaders,json=userBodyObject)
             response = requests.post(endpoint, headers=postHeaders , json = userBodyObject)
             #print(response.json())
+            
             if(response.ok):
                 nSucessfull += 1
                 if(VERBOSE):
@@ -104,6 +106,7 @@ def run():
                 if(VERBOSE):
                     print("Failed creation of: "+str(user[CSV_IND["username"]]))
                     print(response.json())
+            time.sleep(0.3)
         print("---SCRIPT SUMMARY---")
         print("Created: "+ str(nSucessfull)+" Failed: "+str(nFail))
     else:


### PR DESCRIPTION
Auth0 has a limit of 50 users per get request, so added a quick fix in the api for fetching all users. This might prove problematic if there are 0 users. 

Also added a small delay in user-creation script, as to not exceed user-creation limit. 